### PR TITLE
Remove dependency from hard restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Easily consume the following features on any device
 | Raspberry Pi               | [Linux arm 7 static build](https://github.com/daptin/daptin/releases)                                                         |
 
 
+## Read more
+
+
 ## Database persistence
 
 Store data on MySQL, PostgreSQL for heavy use cases (thousands of users) or SQLite for light use cases (iot, embedded).

--- a/daptinweb/src/components/modelform/ModelForm.vue
+++ b/daptinweb/src/components/modelform/ModelForm.vue
@@ -16,10 +16,11 @@
             <select-one-or-more :value="item.value" :schema="item" @save="setRelation"></select-one-or-more>
           </div>
         </div>
+        <div class="col-md-6" v-if="hasPermissionField">
+          <fieldPermissionInput :value="model.permission"></fieldPermissionInput>
+        </div>
       </div>
-      <div class="col-md-6" v-if="hasPermissionField">
-        <fieldPermissionInput :value="model.permission"></fieldPermissionInput>
-      </div>
+
     </div>
     <div class="box-footer">
       <el-button class="bg-yellow" type="submit" v-loading.body="loading" @click.prevent="saveRow()"> Submit

--- a/docs/index.html
+++ b/docs/index.html
@@ -829,5 +829,5 @@
 
 <!--
 MkDocs version : 0.17.2
-Build Date UTC : 2018-03-27 11:24:03
+Build Date UTC : 2018-03-29 18:00:35
 -->

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
     
     <url>
      <loc>/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -13,31 +13,31 @@
         
     <url>
      <loc>/setting-up/settingup/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
         
     <url>
      <loc>/setting-up/entities/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
         
     <url>
      <loc>/setting-up/entity_relations/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
         
     <url>
      <loc>/actions-streams/default_actions/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
         
     <url>
      <loc>/setting-up/database_configuration/</loc>
-     <lastmod>2018-03-27</lastmod>
+     <lastmod>2018-03-29</lastmod>
      <changefreq>daily</changefreq>
     </url>
         

--- a/docs_markdown/mkdocs-material/main.html
+++ b/docs_markdown/mkdocs-material/main.html
@@ -3,3 +3,81 @@
 {% block extrahead %}
 <link href="https://fonts.googleapis.com/css?family=Varela+Round" rel="stylesheet">
 {% endblock %}
+
+
+<script>
+    (function(document, window) {
+
+        var config = {
+            percentages: {
+                each: [10, 90],
+                every: [25]
+            }
+        };
+        var trackerId = 'UA-114227400-1';  // e.g. UA-000000-00
+
+        if (document.readyState !== 'loading') {
+
+            init();
+
+        } else {
+
+            document.addEventListener('DOMContentLoaded', init);
+
+        }
+
+        function init() {
+
+            getTracker(trackerId, registerScrollTracker);
+
+        }
+
+        function registerScrollTracker(tracker) {
+
+            var scrollTracker = window.ScrollTracker();
+            scrollTracker.on(config, function(evt) {
+
+                tracker.send('event', {
+                    eventCategory: 'Scroll Tracking',
+                    eventAction: evt.data.label,
+                    eventLabel: document.location.pathname,
+                    nonInteraction: true
+                });
+
+            });
+
+        }
+
+        function getTracker(trackerId, cb, ran) {
+
+            var ga = window[window.GoogleAnalyticsObject] ;
+
+            ga(function() {
+
+                var trackers = ga.getAll();
+                var len = trackers.length;
+                var tracker;
+                var i;
+
+                for (i = 0; i < len; i++) {
+
+                    tracker = trackers[i];
+
+                    if (tracker.get('trackingId') === trackerId) return cb(tracker);
+
+                }
+
+                if (!ran) {
+
+                    setTimeout(function() {
+                        getTracker(trackerId, cb, true);
+                    }, 0);
+
+                }
+
+            });
+
+        }
+
+    })(document, window);
+</script>

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d7a186a986145151d69567a0cc689156b8913f71317ac55b2b74a15472334d23
-updated: 2018-03-05T14:59:36.693027676+05:30
+hash: 649fb3408abf821e191badc63e004c77dfe52a181f790be925f5a8c6c4e07c10
+updated: 2018-03-29T23:34:43.668732919+05:30
 imports:
 - name: cloud.google.com/go
   version: 24ab414b448dd710f8d7555126880a377ea1a1f4
@@ -120,6 +120,7 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
+  - private/util
   - service/s3
   - service/s3/s3iface
   - service/s3/s3manager
@@ -147,9 +148,9 @@ imports:
 - name: github.com/daaku/go.zipexe
   version: a5fe2436ffcb3236e175e5149162b41cd28bd27d
 - name: github.com/dgrijalva/jwt-go
-  version: dbeaa9332f19a944acb5736b4456cfcc02140e29
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/digitalocean/godo
-  version: 77ea48de76a7b31b234d854f15d003c68bb2fb90
+  version: 7a32b5ce17203924a21366d5031032fd326d5051
 - name: github.com/dlclark/regexp2
   version: 7632a260cbaf5e7594fc1544a503456ecd0827f1
   subpackages:
@@ -172,6 +173,8 @@ imports:
   version: 31534ccd8cac1d3d205c906ea5722928b045ed8c
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+- name: github.com/gedex/inflector
+  version: 16278e9db8130ac7ec405dc174cfb94344f16325
 - name: github.com/GeertJohan/go.rice
   version: c02ca9a983da5807ddf7d796784928f5be4afd09
   subpackages:
@@ -189,14 +192,14 @@ imports:
 - name: github.com/go-ini/ini
   version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
 - name: github.com/go-playground/locales
-  version: e4cbcb5d0652150d40ad0646651076b6bd2be4f6
+  version: f63010822830b6fe52288ee52d5a1151088ce039
   subpackages:
   - currency
   - en
 - name: github.com/go-playground/universal-translator
   version: b32fa301c9fe55953584134cb6853a13c87ec0a1
 - name: github.com/go-playground/validator
-  version: 150fe5b6a4ccc9cd6ffdbf5d184b67fbea75efcc
+  version: 8ce234ff024d85b3848e485decba806385d6e276
 - name: github.com/go-sql-driver/mysql
   version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/gocraft/health
@@ -239,6 +242,19 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 5bbbb5b2b5729b132181cc7f4aa3b3c973e9a0ed
+- name: github.com/graphql-go/graphql
+  version: 1e23489041ba90a66f317fe0deccb236a2fff3cb
+  subpackages:
+  - gqlerrors
+  - language/ast
+  - language/kinds
+  - language/lexer
+  - language/location
+  - language/parser
+  - language/printer
+  - language/source
+  - language/typeInfo
+  - language/visitor
 - name: github.com/hashicorp/hcl
   version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
@@ -339,9 +355,11 @@ imports:
   - hotp
   - totp
 - name: github.com/PuerkitoBio/goquery
-  version: 09540e565986583836b5fc792fe951ec5fd201dd
+  version: a86ea073017a6beddef78c8659e7224e8ca634b0
 - name: github.com/rfjakob/eme
   version: 2222dbd4ba467ab3fc7e8af41562fcfe69c0d770
+- name: github.com/sadlil/go-trigger
+  version: cfc3d83007cddfc1e31a478aa47cd41de07fac17
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sergi/go-diff
@@ -349,7 +367,7 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/skratchdot/open-golang
   version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
   subpackages:
@@ -486,11 +504,11 @@ imports:
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/go-playground/validator.v9
-  version: 150fe5b6a4ccc9cd6ffdbf5d184b67fbea75efcc
+  version: 8ce234ff024d85b3848e485decba806385d6e276
   subpackages:
   - translations/en
 - name: gopkg.in/Masterminds/squirrel.v1
-  version: 2a85d1d526545de922a487d4841e61d6ee690c35
+  version: 40ef4f86bf59a996c348a9f56ddb4c4d3d49a6df
 - name: gopkg.in/src-d/go-billy.v3
   version: c329b7bc7b9d24905d2bc1b85bfa29f7ae266314
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -65,3 +65,5 @@ import:
   version: ^1.1.0
 - package: github.com/digitalocean/godo
   version: ~1.1.1
+- package: github.com/graphql-go/graphql
+  version: ^0.7.5

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,7 +42,6 @@ import:
   version: ^1.0.0
   subpackages:
   - totp
-- package: github.com/artpar/goagain
 - package: github.com/artpar/go.uuid
   version: ^1.2.0
 - package: github.com/sirupsen/logrus

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/GeertJohan/go.rice"
-	//"github.com/artpar/goagain"
 	"github.com/daptin/daptin/server"
 	"github.com/gin-gonic/gin"
 	"github.com/gocraft/health"
@@ -13,10 +12,7 @@ import (
 	"net/http"
 	"github.com/sadlil/go-trigger"
 	"os"
-	"sync"
 	"syscall"
-	"os/signal"
-	//"github.com/artpar/goagain"
 )
 
 // Save the stream as a global variable
@@ -69,12 +65,6 @@ func main() {
 	}
 	log.Printf("Connection acquired from database")
 
-	// Inherit a net.Listener from our parent process or listen anew.
-	//ch := make(chan struct{})
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	//l, err := goagain.Listener()
-
 	var hostSwitch server.HostSwitch
 
 	hostSwitch = server.Main(boxRoot, db)
@@ -89,28 +79,11 @@ func main() {
 		rhs.HostSwitch = &hostSwitch
 	})
 
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Signal(syscall.SIGUSR2))
-	go func() {
-		for sig := range c {
-			switch sig.String() {
-			case "user defined signal 2":
-				log.Printf("Got signal: %v, updatd host switch", sig)
-				hostSwitch = server.Main(boxRoot, db)
-				rhs.HostSwitch = &hostSwitch
-
-			}
-			// sig is a ^C, handle it
-		}
-	}()
-
-	//log.Printf("Listening at: %v", l.Addr().String())
-	//go func() {
+	log.Printf("Listening at: %v", *port)
 	err = http.ListenAndServe(*port, &rhs)
 	if err != nil {
 		panic(err)
 	}
-	//}()
 
 	log.Printf("Why end now ?")
 }

--- a/main.go
+++ b/main.go
@@ -4,30 +4,32 @@ import (
 	"flag"
 	"fmt"
 	"github.com/GeertJohan/go.rice"
-	"github.com/artpar/goagain"
+	//"github.com/artpar/goagain"
 	"github.com/daptin/daptin/server"
-	"github.com/daptin/daptin/server/resource"
 	"github.com/gin-gonic/gin"
 	"github.com/gocraft/health"
 	"github.com/jamiealquiza/envy"
 	"log"
-	"net"
 	"net/http"
+	"github.com/sadlil/go-trigger"
 	"os"
 	"sync"
 	"syscall"
+	"os/signal"
+	//"github.com/artpar/goagain"
 )
 
 // Save the stream as a global variable
 var stream = health.NewStream()
 
 func init() {
-	goagain.Strategy = goagain.Double
+	//goagain.Strategy = goagain.Double
 	log.SetFlags(log.Lmicroseconds | log.Lshortfile)
 	log.SetPrefix(fmt.Sprintf("pid:%d ", syscall.Getpid()))
 }
 
 func main() {
+	//eventEmitter := &emitter.Emitter{}
 
 	var db_type = flag.String("db_type", "sqlite3", "Database to use: sqlite3/mysql/postgres")
 	var connection_string = flag.String("db_connection_string", "daptin.db", "\n\tSQLite: test.db\n"+
@@ -35,8 +37,8 @@ func main() {
 		"\tPostgres: host=<hostname> port=<port> user=<username> password=<password> dbname=<db_name> sslmode=enable/disable")
 
 	var webDashboardSource = flag.String("dashboard", "daptinweb/dist", "path to dist folder for daptin web dashboard")
-	var assetsSource = flag.String("assets", "assets", "path to folder for assets")
-	var port = flag.String("port", "6336", "Daptin port")
+	//var assetsSource = flag.String("assets", "assets", "path to folder for assets")
+	var port = flag.String("port", ":6336", "Daptin port")
 	var runtimeMode = flag.String("runtime", "debug", "Runtime for Gin: debug, test, release")
 
 	gin.SetMode(*runtimeMode)
@@ -45,84 +47,78 @@ func main() {
 	flag.Parse()
 
 	stream.AddSink(&health.WriterSink{os.Stdout})
-	assetsRoot, err := rice.FindBox("assets")
-	resource.CheckErr(err, "Failed to open %s/static", assetsSource)
+	//assetsRoot, err := rice.FindBox("assets")
+	//resource.CheckErr(err, "Failed to open %s/static", assetsSource)
 	boxRoot1, err := rice.FindBox("daptinweb/dist/")
-	resource.CheckErr(err, "Failed to open %s", webDashboardSource)
+	if err != nil {
+		panic(err)
+	}
 
-	var assetsStatic, boxRoot http.FileSystem
+	var boxRoot http.FileSystem
 	if err != nil {
 		log.Printf("Try loading web dashboard from: %v", *webDashboardSource)
-		assetsStatic = http.Dir(*webDashboardSource + "/static")
+		//assetsStatic = http.Dir(*webDashboardSource + "/static")
 		boxRoot = http.Dir(*webDashboardSource)
 	} else {
-		assetsStatic = assetsRoot.HTTPBox()
+		//assetsStatic = assetsRoot.HTTPBox()
 		boxRoot = boxRoot1.HTTPBox()
 	}
 	db, err := server.GetDbConnection(*db_type, *connection_string)
-	resource.CheckErr(err, "Failed to connect to database")
+	if err != nil {
+		panic(err)
+	}
 	log.Printf("Connection acquired from database")
 
 	// Inherit a net.Listener from our parent process or listen anew.
-	ch := make(chan struct{})
+	//ch := make(chan struct{})
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	l, err := goagain.Listener()
-	if nil != err {
+	//l, err := goagain.Listener()
 
-		// Listen on a TCP or a UNIX domain socket (TCP here).
-		l, err = net.Listen("tcp", fmt.Sprintf(":%v", *port))
-		if nil != err {
-			log.Printf("Failed to listen to port: %v", err)
-			// no return no panic here for proper restart
-		} else {
-			log.Println("listening on", l.Addr())
-			// Accept connections in a new goroutine.
-			go server.Main(boxRoot, assetsStatic, db, wg, l, ch)
+	var hostSwitch server.HostSwitch
 
-		}
-
-	} else {
-
-		// Resume listening and accepting connections in a new goroutine.
-		log.Println("resuming listening on", l.Addr())
-		go server.Main(boxRoot, assetsStatic, db, wg, l, ch)
-
-		// If this is the child, send the parent SIGUSR2.  If this is the
-		// parent, send the child SIGQUIT.
-		if err := goagain.Kill(); nil != err {
-			log.Fatalln(err)
-		}
-
+	hostSwitch = server.Main(boxRoot, db)
+	rhs := RestartHandlerServer{
+		HostSwitch: &hostSwitch,
 	}
 
-	// Block the main goroutine awaiting signals.
-	sig, err := goagain.Wait(l)
-	if nil != err {
-		log.Fatalln(err)
-	}
+	trigger.On("restart", func() {
+		// Do Some Task Here.
+		log.Printf("Trigger restart")
+		hostSwitch = server.Main(boxRoot, db)
+		rhs.HostSwitch = &hostSwitch
+	})
 
-	// Do whatever's necessary to ensure a graceful exit like waiting for
-	// goroutines to terminate or a channel to become closed.
-	//
-	// In this case, we'll close the channel to signal the goroutine to stop
-	// accepting connections and wait for the goroutine to exit.
-	close(ch)
-	wg.Wait()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Signal(syscall.SIGUSR2))
+	go func() {
+		for sig := range c {
+			switch sig.String() {
+			case "user defined signal 2":
+				log.Printf("Got signal: %v, updatd host switch", sig)
+				hostSwitch = server.Main(boxRoot, db)
+				rhs.HostSwitch = &hostSwitch
 
-	// If we received SIGUSR2, re-exec the parent process.
-	log.Printf("Daptin main signal received: %v", sig)
-	if goagain.SIGUSR2 == sig {
-		if err := goagain.Exec(l); nil != err {
-			log.Fatalln(err)
+			}
+			// sig is a ^C, handle it
 		}
+	}()
+
+	//log.Printf("Listening at: %v", l.Addr().String())
+	//go func() {
+	err = http.ListenAndServe(*port, &rhs)
+	if err != nil {
+		panic(err)
 	}
+	//}()
+
 	log.Printf("Why end now ?")
 }
 
-//func CreateServerProgram(boxRoot, boxStatic http.FileSystem) (func(state overseer.State)) {
-//	return func(state overseer.State) {
-//		go server.Main(boxRoot, boxStatic)
-//		http.Serve(state.Listener, nil)
-//	}
-//}
+type RestartHandlerServer struct {
+	HostSwitch *server.HostSwitch
+}
+
+func (rhs *RestartHandlerServer) ServeHTTP(rew http.ResponseWriter, req *http.Request) {
+	rhs.HostSwitch.ServeHTTP(rew, req)
+}

--- a/server/resource/action_restart_system.go
+++ b/server/resource/action_restart_system.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	log "github.com/sirupsen/logrus"
-	"syscall"
+	//"syscall"
 	"time"
 	//"os/exec"
 	//"fmt"
@@ -54,7 +54,7 @@ func restart() {
 	log.Infof("Sleeping for 3 seconds before restart")
 	time.Sleep(300 * time.Millisecond)
 	log.Infof("Kill")
-	log.Infof("Sending %v to %v", syscall.SIGUSR2, syscall.Getpid())
+	//log.Infof("Sending %v to %v", syscall.SIGUSR2, syscall.Getpid())
 
 	//exec.Command("kill", "-12", fmt.Sprint(syscall.Getpid())).Output()
 	trigger.Fire("restart")

--- a/server/resource/action_restart_system.go
+++ b/server/resource/action_restart_system.go
@@ -7,6 +7,7 @@ import (
 	//"os/exec"
 	//"fmt"
 	"github.com/artpar/api2go"
+	"github.com/sadlil/go-trigger"
 )
 
 type RestartSystemActionPerformer struct {
@@ -56,7 +57,7 @@ func restart() {
 	log.Infof("Sending %v to %v", syscall.SIGUSR2, syscall.Getpid())
 
 	//exec.Command("kill", "-12", fmt.Sprint(syscall.Getpid())).Output()
-
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR2)
+	trigger.Fire("restart")
+	//syscall.Kill(syscall.Getpid(), syscall.SIGUSR2)
 
 }

--- a/server/resource/column_types.go
+++ b/server/resource/column_types.go
@@ -7,6 +7,7 @@ import (
 	validator2 "gopkg.in/go-playground/validator.v9"
 	"math/rand"
 	"time"
+	"github.com/graphql-go/graphql"
 )
 
 type Faker interface {
@@ -20,6 +21,7 @@ type ColumnType struct {
 	Conformations []string
 	ReclineType   string
 	DataTypes     []string
+	GraphqlType   *graphql.Scalar
 }
 
 func randate() time.Time {
@@ -118,30 +120,35 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{},
 		DataTypes:     []string{"varchar(20)", "varchar(10)"},
+		GraphqlType:   graphql.ID,
 	},
 	{
 		Name:          "alias",
 		BlueprintType: "string",
 		ReclineType:   "string",
 		DataTypes:     []string{"varchar(100)", "varchar(20)", "varchar(10)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "date",
 		BlueprintType: "date-only",
 		ReclineType:   "date",
 		DataTypes:     []string{"timestamp"},
+		GraphqlType:   graphql.DateTime,
 	},
 	{
 		Name:          "time",
 		BlueprintType: "time-only",
 		ReclineType:   "time",
 		DataTypes:     []string{"timestamp"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "day",
 		BlueprintType: "string",
 		ReclineType:   "string",
 		DataTypes:     []string{"varchar(10)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "month",
@@ -149,6 +156,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"min=1,max=12"},
 		DataTypes:     []string{"int(4)"},
+		GraphqlType:   graphql.Int,
 	},
 	{
 		Name:          "year",
@@ -156,24 +164,28 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"min=1900,max=2100"},
 		DataTypes:     []string{"int(4)"},
+		GraphqlType:   graphql.Int,
 	},
 	{
 		Name:          "minute",
 		BlueprintType: "number",
 		Validations:   []string{"min=0,max=59"},
 		DataTypes:     []string{"int(4)"},
+		GraphqlType:   graphql.Int,
 	},
 	{
 		Name:          "hour",
 		BlueprintType: "number",
 		ReclineType:   "string",
 		DataTypes:     []string{"int(4)"},
+		GraphqlType:   graphql.Int,
 	},
 	{
 		Name:          "datetime",
 		BlueprintType: "datetime",
 		ReclineType:   "date-time",
 		DataTypes:     []string{"timestamp"},
+		GraphqlType:   graphql.DateTime,
 	},
 	{
 		Name:          "email",
@@ -182,12 +194,14 @@ var ColumnTypes = []ColumnType{
 		Validations:   []string{"email"},
 		Conformations: []string{"email"},
 		DataTypes:     []string{"varchar(100)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "namespace",
 		BlueprintType: "string",
 		ReclineType:   "string",
 		DataTypes:     []string{"varchar(200)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "name",
@@ -196,18 +210,21 @@ var ColumnTypes = []ColumnType{
 		Validations:   []string{"required"},
 		Conformations: []string{"name"},
 		DataTypes:     []string{"varchar(100)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "encrypted",
 		ReclineType:   "string",
 		BlueprintType: "string",
 		DataTypes:     []string{"varchar(100)", "varchar(500)", "varchar(500)", "text"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "json",
 		ReclineType:   "string",
 		BlueprintType: "string",
 		DataTypes:     []string{"text", "varchar(100)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "password",
@@ -215,30 +232,35 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"required"},
 		DataTypes:     []string{"varchar(200)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "value",
 		ReclineType:   "string",
-		BlueprintType: "number",
+		BlueprintType: "string",
 		DataTypes:     []string{"varchar(100)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "truefalse",
 		BlueprintType: "boolean",
 		ReclineType:   "boolean",
 		DataTypes:     []string{"boolean"},
+		GraphqlType:   graphql.Boolean,
 	},
 	{
 		Name:          "timestamp",
 		BlueprintType: "datetime",
 		ReclineType:   "date-time",
 		DataTypes:     []string{"timestamp"},
+		GraphqlType:   graphql.DateTime,
 	},
 	{
 		Name:          "location",
 		BlueprintType: "string",
 		ReclineType:   "geo_point",
 		DataTypes:     []string{"varchar(50)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "location.latitude",
@@ -246,6 +268,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "number",
 		Validations:   []string{"latitude"},
 		DataTypes:     []string{"float(7,4)"},
+		GraphqlType:   graphql.Float,
 	},
 	{
 		Name:          "location.longitude",
@@ -253,12 +276,14 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "number",
 		Validations:   []string{"longitude"},
 		DataTypes:     []string{"float(7,4)"},
+		GraphqlType:   graphql.Float,
 	},
 	{
 		Name:          "location.altitude",
 		BlueprintType: "number",
 		ReclineType:   "number",
 		DataTypes:     []string{"float(7,4)"},
+		GraphqlType:   graphql.Float,
 	},
 	{
 		Name:          "color",
@@ -266,6 +291,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"iscolor"},
 		DataTypes:     []string{"varchar(50)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "rating.10",
@@ -273,24 +299,35 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"min=0,max=10"},
 		DataTypes:     []string{"int(4)"},
+		GraphqlType:   graphql.Int,
 	},
 	{
 		Name:          "measurement",
 		ReclineType:   "number",
 		BlueprintType: "number",
 		DataTypes:     []string{"int(10)"},
+		GraphqlType:   graphql.Int,
+	},
+	{
+		Name:          "float",
+		ReclineType:   "number",
+		BlueprintType: "number",
+		DataTypes:     []string{"float(7,4)"},
+		GraphqlType:   graphql.Float,
 	},
 	{
 		Name:          "label",
 		ReclineType:   "string",
 		BlueprintType: "string",
 		DataTypes:     []string{"varchar(100)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "content",
 		ReclineType:   "string",
 		BlueprintType: "string",
 		DataTypes:     []string{"text"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "file",
@@ -298,6 +335,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "binary",
 		Validations:   []string{"base64"},
 		DataTypes:     []string{"blob"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "image",
@@ -305,6 +343,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "binary",
 		Validations:   []string{"base64"},
 		DataTypes:     []string{"blob"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "url",
@@ -312,6 +351,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "string",
 		Validations:   []string{"url"},
 		DataTypes:     []string{"varchar(500)"},
+		GraphqlType:   graphql.String,
 	},
 	{
 		Name:          "image",
@@ -319,6 +359,7 @@ var ColumnTypes = []ColumnType{
 		ReclineType:   "binary",
 		Validations:   []string{"base64"},
 		DataTypes:     []string{"text"},
+		GraphqlType:   graphql.String,
 	},
 }
 
@@ -336,8 +377,11 @@ func InitialiseColumnManager() {
 	}
 }
 
-func (ctm *ColumnTypeManager) GetBlueprintType(colName string) string {
-	return ctm.ColumnMap[colName].BlueprintType
+func (ctm *ColumnTypeManager) GetBlueprintType(columnType string) string {
+	return ctm.ColumnMap[columnType].BlueprintType
+}
+func (ctm *ColumnTypeManager) GetGraphqlType(columnType string) *graphql.Scalar {
+	return ctm.ColumnMap[columnType].GraphqlType
 }
 
 func (ctm *ColumnTypeManager) GetFakedata(colTypeName string) string {

--- a/server/server.go
+++ b/server/server.go
@@ -15,12 +15,157 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/thoas/stats"
 	"io/ioutil"
-	//"net"
 	"net/http"
-	//"sync"
+	"github.com/graphql-go/graphql"
+	"fmt"
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/private/util"
+	"github.com/gedex/inflector"
 )
 
 var Stats = stats.New()
+
+func MakeGraphqlSchema(cmsConfig *resource.CmsConfig, resources map[string]*resource.DbResource) *graphql.Schema {
+
+	graphqlTypesMap := make(map[string]*graphql.Object)
+	mutations := make(graphql.Fields)
+	query := make(graphql.Fields)
+
+	for _, table := range cmsConfig.Tables {
+
+		fields := make(graphql.Fields)
+
+		for _, column := range table.Columns {
+
+			fields[column.ColumnName] = &graphql.Field{
+				Type: resource.ColumnManager.GetGraphqlType(column.ColumnType),
+				Name: column.Name,
+			}
+		}
+
+		objectConfig := graphql.NewObject(graphql.ObjectConfig{
+			Name:   table.TableName,
+			Fields: fields,
+		})
+
+		graphqlTypesMap[table.TableName] = objectConfig
+
+		createFields := make(graphql.FieldConfigArgument)
+
+		for _, column := range table.Columns {
+			if IsStandardColumn(column.ColumnName) {
+				continue
+			}
+
+			if column.IsForeignKey {
+				continue
+			}
+
+			if column.IsNullable {
+				createFields[column.ColumnName] = &graphql.ArgumentConfig{
+					Type: resource.ColumnManager.GetGraphqlType(column.ColumnType),
+				}
+			} else {
+				createFields[column.ColumnName] = &graphql.ArgumentConfig{
+					Type: graphql.NewNonNull(resource.ColumnManager.GetGraphqlType(column.ColumnType)),
+				}
+			}
+
+		}
+
+		mutations["create"+util.Capitalize(table.TableName)] = &graphql.Field{
+			Type:        graphqlTypesMap[table.TableName],
+			Description: "Create a new " + table.TableName,
+			Args:        createFields,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				log.Printf("create resolve params: %v", p)
+				return nil, nil
+			},
+		}
+
+		mutations["update"+util.Capitalize(table.TableName)] = &graphql.Field{
+			Type:        graphqlTypesMap[table.TableName],
+			Description: "Create a new " + table.TableName,
+			Args:        createFields,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				log.Printf("create resolve params: %v", p)
+				return nil, nil
+			},
+		}
+
+		query[table.TableName] = &graphql.Field{
+			Type:        graphqlTypesMap[table.TableName],
+			Description: "Get a single " + table.TableName,
+			Args: graphql.FieldConfigArgument{
+				"id": &graphql.ArgumentConfig{
+					Type:        graphql.String,
+					Description: "id of the " + table.TableName,
+				},
+			},
+			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+
+				//params.Args["id"].(string)
+
+				return nil, nil
+
+			},
+		}
+
+		query[table.TableName+"List"] = &graphql.Field{
+			Type:        graphqlTypesMap[table.TableName],
+			Description: "Get a list of " + inflector.Pluralize(table.TableName),
+			Args: graphql.FieldConfigArgument{
+
+			},
+			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+
+				//params.Args["id"].(string)
+
+				return nil, nil
+
+			},
+		}
+
+	}
+
+	var rootMutation = graphql.NewObject(graphql.ObjectConfig{
+		Name:   "RootMutation",
+		Fields: mutations,
+	});
+	var rootQuery = graphql.NewObject(graphql.ObjectConfig{
+		Name:   "RootQuery",
+		Fields: query,
+	})
+
+	// define schema, with our rootQuery and rootMutation
+	var schema, _ = graphql.NewSchema(graphql.SchemaConfig{
+		Query:    rootQuery,
+		Mutation: rootMutation,
+	})
+
+	return &schema
+
+}
+
+func IsStandardColumn(s string) bool {
+	for _, cols := range resource.StandardColumns {
+		if cols.ColumnName == s {
+			return true
+		}
+	}
+	return false
+}
+
+func executeQuery(query string, schema graphql.Schema) *graphql.Result {
+	result := graphql.Do(graphql.Params{
+		Schema:        schema,
+		RequestString: query,
+	})
+	if len(result.Errors) > 0 {
+		fmt.Printf("wrong result, unexpected errors: %v", result.Errors)
+	}
+	return result
+}
 
 func Main(boxRoot http.FileSystem, db database.DatabaseConnection) HostSwitch {
 
@@ -153,18 +298,6 @@ func Main(boxRoot http.FileSystem, db database.DatabaseConnection) HostSwitch {
 
 	hostSwitch.handlerMap["api"] = r
 	hostSwitch.handlerMap["dashboard"] = r
-	//hostSwitch.siteMap["dashboard"] = resource.SubSite{
-	//	Id:           int64(0),
-	//	Name:         "dashboard",
-	//	Hostname:     "dashboard",
-	//	Path:         "dashboard",
-	//	CloudStoreId: nil,
-	//	Permission: resource.PermissionInstance{
-	//		UserId:      "",
-	//		UserGroupId: []auth.GroupPermission{},
-	//		Permission:  auth.DEFAULT_PERMISSION,
-	//	},
-	//}
 
 	authMiddleware.SetUserCrud(cruds["user"])
 	authMiddleware.SetUserGroupCrud(cruds["usergroup"])
@@ -181,6 +314,13 @@ func Main(boxRoot http.FileSystem, db database.DatabaseConnection) HostSwitch {
 	blueprintHandler := CreateApiBlueprintHandler(&initConfig, cruds)
 	modelHandler := CreateReclineModelHandler()
 	statsHandler := CreateStatsHandler(&initConfig, cruds)
+
+	graphqlSchema := MakeGraphqlSchema(&initConfig, cruds)
+	r.GET("/graphql", func(context *gin.Context) {
+		log.Infof("graphql query: %v", context.Query("query"))
+		result := executeQuery(context.Query("query"), *graphqlSchema)
+		json.NewEncoder(context.Writer).Encode(result)
+	})
 
 	r.GET("/jsmodel/:typename", handler)
 	r.GET("/stats/:typename", statsHandler)

--- a/server/server.go
+++ b/server/server.go
@@ -15,17 +15,15 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/thoas/stats"
 	"io/ioutil"
-	"net"
+	//"net"
 	"net/http"
-	"sync"
+	//"sync"
 )
 
 var Stats = stats.New()
 
-func Main(boxRoot, assetsStatic http.FileSystem, db database.DatabaseConnection, wg *sync.WaitGroup, l net.Listener, ch chan struct{}) {
-	defer wg.Done()
+func Main(boxRoot http.FileSystem, db database.DatabaseConnection) HostSwitch {
 
-	//configFile := "daptin_style.json"
 	/// Start system initialise
 
 	log.Infof("Load config files")
@@ -37,7 +35,6 @@ func Main(boxRoot, assetsStatic http.FileSystem, db database.DatabaseConnection,
 	}
 
 	existingTables, _ := GetTablesFromWorld(db)
-	//initConfig.Tables = append(initConfig.Tables, existingTables...)
 
 	allTables := MergeTables(existingTables, initConfig.Tables)
 
@@ -232,19 +229,10 @@ func Main(boxRoot, assetsStatic http.FileSystem, db database.DatabaseConnection,
 	//r.Run(fmt.Sprintf(":%v", *port))
 	CleanUpConfigFiles()
 
-	log.Printf("Listening at: %v", l.Addr().String())
-	go func() {
-		err = http.Serve(l, hostSwitch)
-		resource.CheckErr(err, "Failed to listen")
-	}()
-
-	select {
-	case <-ch:
-		return
-	default:
-	}
+	return hostSwitch
 
 }
+
 func MergeTables(existingTables []resource.TableInfo, initConfigTables []resource.TableInfo) []resource.TableInfo {
 	allTables := make([]resource.TableInfo, 0)
 	existingTablesMap := make(map[string]bool)


### PR DESCRIPTION
Remove dependency from process restarts which were required to update schema and rebind http paths. All parts will happen in runtime now without an actual restart.

- Can build static binaries for windows 32/64 platforms
- Removes dependency from syscall.SIGUSR2