### PR TITLE
fix: avoid 500 on JSON:API reads for system tables with empty default_order

### DIFF
--- a/server/resource/resource_findallpaginated.go
+++ b/server/resource/resource_findallpaginated.go
@@ -183,6 +183,80 @@ type column struct {
 	reference     string
 }
 
+// resolveDefaultSortOrder turns a world.default_order value into a list of
+// sort tokens. It tolerates quoted, empty, whitespace-only and malformed values
+// (e.g. a bare "-") so they can never reach the query builder as an empty
+// identifier. When no usable token remains it falls back to the documented
+// "-created_at" default, but only when the physical table actually has a
+// created_at column; otherwise it returns nil so the caller omits ORDER BY
+// instead of emitting an empty backtick-quoted identifier.
+func resolveDefaultSortOrder(defaultOrder string, hasCreatedAt bool) []string {
+	defaultOrder = strings.TrimSpace(defaultOrder)
+	if len(defaultOrder) > 1 && (defaultOrder[0] == '\'' || defaultOrder[0] == '"') {
+		rep := strings.ReplaceAll(defaultOrder, "'", "\"")
+		if unquotedOrder, err := strconv.Unquote(rep); err == nil {
+			defaultOrder = strings.TrimSpace(unquotedOrder)
+		}
+	}
+
+	if defaultOrder != "" {
+		parts := strings.Split(defaultOrder, ",")
+		cleaned := make([]string, 0, len(parts))
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			// drop empty segments and bare sign tokens ("-", "+") that would
+			// otherwise become an empty column identifier.
+			if part == "" || part == "-" || part == "+" {
+				continue
+			}
+			cleaned = append(cleaned, part)
+		}
+		if len(cleaned) > 0 {
+			return cleaned
+		}
+	}
+
+	if hasCreatedAt {
+		return []string{"-created_at"}
+	}
+	return nil
+}
+
+// buildOrderExpressions converts sort tokens into goqu ordered expressions.
+// prefix is the table-qualified column prefix (e.g. "world."). Tokens that are
+// empty, whitespace-only or just a bare sign are skipped so an empty identifier
+// can never be interpolated into the generated SQL.
+func buildOrderExpressions(sortOrder []string, prefix string) []exp.OrderedExpression {
+	orders := make([]exp.OrderedExpression, 0, len(sortOrder))
+	for _, so := range sortOrder {
+		so = strings.TrimSpace(so)
+		if so == "" {
+			continue
+		}
+		switch so[0] {
+		case '-':
+			col := strings.TrimSpace(so[1:])
+			if col == "" {
+				continue
+			}
+			orders = append(orders, goqu.I(prefix+col).Desc())
+		case '+':
+			col := strings.TrimSpace(so[1:])
+			if col == "" {
+				continue
+			}
+			orders = append(orders, goqu.I(prefix+col).Asc())
+		default:
+			if strings.ToLower(so) == "rand()" || strings.ToLower(so) == "random()" {
+				orders = append(orders, goqu.I(so).Asc())
+			} else {
+				orders = append(orders, goqu.I(prefix+so).Asc())
+			}
+		}
+	}
+	return orders
+}
+
 // PaginatedFindAll(req Request) (totalCount uint, response Responder, err error)
 func (dbResource *DbResource) PaginatedFindAllWithoutFilters(req api2go.Request, transaction *sqlx.Tx) (
 	[]map[string]interface{}, [][]map[string]interface{}, *PaginationData, bool, error) {
@@ -300,15 +374,9 @@ func (dbResource *DbResource) PaginatedFindAllWithoutFilters(req api2go.Request,
 	var sortOrder []string
 	if len(req.QueryParams["sort"]) > 0 {
 		sortOrder = req.QueryParams["sort"]
-	} else if dbResource.tableInfo.DefaultOrder != "" && len(dbResource.tableInfo.DefaultOrder) > 2 {
-		if dbResource.tableInfo.DefaultOrder[0] == '\'' || dbResource.tableInfo.DefaultOrder[0] == '"' {
-			rep := strings.ReplaceAll(dbResource.tableInfo.DefaultOrder, "'", "\"")
-			unquotedOrder, _ := strconv.Unquote(rep)
-			dbResource.tableInfo.DefaultOrder = unquotedOrder
-		}
-		sortOrder = strings.Split(dbResource.tableInfo.DefaultOrder, ",")
 	} else {
-		sortOrder = []string{"-created_at"}
+		_, hasCreatedAt := dbResource.tableInfo.GetColumnByName("created_at")
+		sortOrder = resolveDefaultSortOrder(dbResource.tableInfo.DefaultOrder, hasCreatedAt)
 	}
 
 	var filters []string
@@ -913,35 +981,7 @@ func (dbResource *DbResource) PaginatedFindAllWithoutFilters(req api2go.Request,
 		}
 	}
 
-	orders := make([]exp.OrderedExpression, 0)
-	for _, so := range sortOrder {
-
-		if len(so) < 1 {
-			continue
-		}
-		//log.Printf("Sort order: %v", so)
-		if so[0] == '-' {
-			//ord := prefix + so[1:] + " desc"
-			// queryBuilder = queryBuilder.OrderBy(ord)
-			// countQueryBuilder = countQueryBuilder.OrderBy(ord)
-			orders = append(orders, goqu.I(prefix+so[1:]).Desc())
-		} else {
-			if so[0] == '+' {
-				//ord := prefix + so[1:] + " asc"
-				// queryBuilder = queryBuilder.OrderBy(ord)
-				// countQueryBuilder = countQueryBuilder.OrderBy(ord)
-				orders = append(orders, goqu.I(prefix+so[1:]).Asc())
-			} else {
-				ord := prefix + so
-				if strings.ToLower(so) == "rand()" || strings.ToLower(so) == "random()" {
-					ord = so
-				}
-				// queryBuilder = queryBuilder.OrderBy(ord)
-				// countQueryBuilder = countQueryBuilder.OrderBy(ord)
-				orders = append(orders, goqu.I(ord).Asc())
-			}
-		}
-	}
+	orders := buildOrderExpressions(sortOrder, prefix)
 
 	if !isAdmin && tableModel.GetTableName() != "usergroup" {
 

--- a/server/resource/resource_findallpaginated_test.go
+++ b/server/resource/resource_findallpaginated_test.go
@@ -1,0 +1,135 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
+)
+
+// TestResolveDefaultSortOrder covers the JSON:API read regression reported in
+// daptin#213, where a system table with an empty/malformed world.default_order
+// produced an empty backtick identifier and a 500 ("unrecognized token: \"`\"").
+func TestResolveDefaultSortOrder(t *testing.T) {
+	tests := []struct {
+		name         string
+		defaultOrder string
+		hasCreatedAt bool
+		want         []string
+	}{
+		{
+			name:         "empty default with created_at falls back to -created_at",
+			defaultOrder: "",
+			hasCreatedAt: true,
+			want:         []string{"-created_at"},
+		},
+		{
+			name:         "whitespace default with created_at falls back to -created_at",
+			defaultOrder: "   ",
+			hasCreatedAt: true,
+			want:         []string{"-created_at"},
+		},
+		{
+			name:         "empty default without created_at omits order",
+			defaultOrder: "",
+			hasCreatedAt: false,
+			want:         nil,
+		},
+		{
+			name:         "bare-dash default with created_at falls back to -created_at",
+			defaultOrder: "'-'",
+			hasCreatedAt: true,
+			want:         []string{"-created_at"},
+		},
+		{
+			name:         "bare-dash default without created_at omits order",
+			defaultOrder: "-",
+			hasCreatedAt: false,
+			want:         nil,
+		},
+		{
+			name:         "quoted default order is honored",
+			defaultOrder: "'-created_at'",
+			hasCreatedAt: true,
+			want:         []string{"-created_at"},
+		},
+		{
+			name:         "comma-separated default order drops empty segments",
+			defaultOrder: "-created_at,, +name",
+			hasCreatedAt: true,
+			want:         []string{"-created_at", "+name"},
+		},
+		{
+			name:         "plain default order is honored",
+			defaultOrder: "name",
+			hasCreatedAt: false,
+			want:         []string{"name"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDefaultSortOrder(tc.defaultOrder, tc.hasCreatedAt)
+			if len(got) != len(tc.want) {
+				t.Fatalf("resolveDefaultSortOrder(%q, %v) = %v, want %v", tc.defaultOrder, tc.hasCreatedAt, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("resolveDefaultSortOrder(%q, %v)[%d] = %q, want %q", tc.defaultOrder, tc.hasCreatedAt, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBuildOrderExpressionsNeverEmptyIdentifier asserts that no combination of
+// empty, whitespace, or bare-sign tokens ever yields an empty backtick-quoted
+// identifier in the generated SQL - the exact failure from daptin#213.
+func TestBuildOrderExpressionsNeverEmptyIdentifier(t *testing.T) {
+	dialect := goqu.Dialect("sqlite3")
+	prefix := "llm_usage."
+
+	// Tokens that previously produced an empty identifier must yield no ORDER BY.
+	for _, badTokens := range [][]string{
+		{"-"},
+		{"+"},
+		{""},
+		{"   "},
+		{"-", "+", ""},
+	} {
+		orders := buildOrderExpressions(badTokens, prefix)
+		if len(orders) != 0 {
+			t.Fatalf("buildOrderExpressions(%v) produced %d orders, want 0", badTokens, len(orders))
+		}
+		sql, _, err := dialect.From("llm_usage").Order(orders...).ToSQL()
+		if err != nil {
+			t.Fatalf("ToSQL for %v returned error: %v", badTokens, err)
+		}
+		if strings.Contains(sql, "``") {
+			t.Fatalf("buildOrderExpressions(%v) produced empty backtick identifier in SQL: %s", badTokens, sql)
+		}
+		if strings.Contains(sql, "ORDER BY") {
+			t.Fatalf("buildOrderExpressions(%v) unexpectedly produced ORDER BY: %s", badTokens, sql)
+		}
+	}
+
+	// A valid fallback token must produce a well-formed ORDER BY with no empty identifier.
+	orders := buildOrderExpressions([]string{"-created_at"}, prefix)
+	if len(orders) != 1 {
+		t.Fatalf("buildOrderExpressions([-created_at]) produced %d orders, want 1", len(orders))
+	}
+	sql, _, err := dialect.From("llm_usage").Order(orders...).ToSQL()
+	if err != nil {
+		t.Fatalf("ToSQL for valid order returned error: %v", err)
+	}
+	if strings.Contains(sql, "``") {
+		t.Fatalf("valid order produced empty backtick identifier: %s", sql)
+	}
+	if !strings.Contains(sql, "`llm_usage`.`created_at`") {
+		t.Fatalf("expected qualified created_at column in SQL, got: %s", sql)
+	}
+	if !strings.Contains(sql, "ORDER BY") {
+		t.Fatalf("expected ORDER BY for valid order, got: %s", sql)
+	}
+}


### PR DESCRIPTION
## Summary

Authenticated JSON:API reads returned HTTP 500 (`unrecognized token: "`"`) for system tables whose `world.default_order` is empty or malformed, as reported in #213 for `llm_usage` (and confirmed by the maintainer for `credential`, `api_usage`, and `api_quota`).

When `default_order` was empty, whitespace-only, or unquoted to a bare sign (e.g. `'-'`), the order token reached the query builder as `goqu.I(prefix + "")`, emitting an empty backtick-quoted identifier into the generated `ORDER BY`. SQLite then rejected the stray backtick, so listing these tables failed even when zero rows existed.

This change resolves the default sort order defensively in `server/resource/resource_findallpaginated.go`:

- `resolveDefaultSortOrder` trims and unquotes the stored value, splits on commas, and drops empty/whitespace/bare-sign segments. It falls back to the documented `-created_at` default only when the physical table actually has a `created_at` column; otherwise it returns no order so the caller omits `ORDER BY` instead of emitting an empty identifier.
- `buildOrderExpressions` sanitizes every order token (including any from a `sort` query param) before it reaches `goqu`, so an empty column identifier can never be interpolated into the SQL.

## Why this matters

This blocks JSON:API listing of affected system tables for any deployment whose `world` rows carry an empty `default_order`, with no workaround short of editing the database. The fix restores reads without changing behavior for tables that already have a valid `default_order` or an explicit `sort` parameter.

## Testing

Added `server/resource/resource_findallpaginated_test.go`:

- `TestResolveDefaultSortOrder` covers empty / whitespace / bare-dash / quoted / comma-separated default orders, both with and without a `created_at` column, asserting the documented fallback and the no-`ORDER BY` path.
- `TestBuildOrderExpressionsNeverEmptyIdentifier` renders the resulting SQL with the sqlite3 dialect and asserts that malformed tokens never produce an empty backtick identifier, while a valid token yields a well-formed `ORDER BY \`llm_usage\`.\`created_at\``.

`gofmt`, `go vet ./server/resource/...`, and `go test ./server/resource/...` all pass.

Fixes #213
